### PR TITLE
Sort icon names in README

### DIFF
--- a/scripts/readme_gen.rb
+++ b/scripts/readme_gen.rb
@@ -5,6 +5,7 @@ template = File.join(__dir__, 'README_template.md')
 readme = File.join(__dir__, '..', 'README_template.md')
 list = Dir.glob(File.join(icons, '*.svg'))
   .map{|f| File.basename(f, '.svg')}
+  .sort
   .map{|n| "- `<icon-#{n}></icon-#{n}>`"}
   .join("\n")
 puts(File.read(template) + list)


### PR DESCRIPTION
Prevent many replacemenmts when updating the list. File globbing order depends on the local file system.

Useful when upgrading to the newest version of bytesize-icons and updating the README.