### PR TITLE
Convert multiple custom elements to just one

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,15 @@
+{
+  // Use IntelliSense to learn about possible attributes.
+  // Hover to view descriptions of existing attributes.
+  // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "gen:index",
+      "type": "Ruby",
+      "request": "launch",
+      "program": "./scripts/generate.rb",
+      "cwd": "${workspaceFolder}"
+    }
+  ]
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,8 @@
+{
+  "search.exclude": {
+    "**/node_modules": true,
+    "README.md": true,
+    "index.js": true,
+    "package-lock.json": true
+  }
+}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ $ npm install --save bytesize-icon-elements
 
     Icon size is variable because it's SVG.
 
-    This is a big flag icon: <icon-flag width="64" height="64"></icon-flag>
+    This is a big flag icon: <icon-flag size="64"></icon-flag>
   </body>
   <script src="/path/to/bytesize-icon-elements/index.js"></script>
 </html>
@@ -37,9 +37,7 @@ Each icon has below optional properties.
 | Name     | Description                                                                                                           | Default   |
 |----------|-----------------------------------------------------------------------------------------------------------------------|-----------|
 | `weight`   | One of `ultra-light`, `thin`, `light`, `regular`, `medium`, `bold` and `heavy`. It determines `stroke-width` of icon. | `regular` |
-| `width`  | Width of icon (in pixels).                                                                                            | `32`      |
-| `height` | Height of icon (in pixels).                                                                                           | `32`      |
-
+| `size`  | Size (width and height) of icon (in pixels).                                                                                            | `32`      |
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ npm install --save bytesize-icon-elements
   <body>
     This is search icon: <icon-search></icon-search>
 
-    And this is a thin book icon: <icon-book type="thin"></icon-book>
+    And this is a thin book icon: <icon-book weight="thin"></icon-book>
 
     Icon size is variable because it's SVG.
 
@@ -36,7 +36,7 @@ Each icon has below optional properties.
 
 | Name     | Description                                                                                                           | Default   |
 |----------|-----------------------------------------------------------------------------------------------------------------------|-----------|
-| `type`   | One of `ultra-light`, `thin`, `light`, `regular`, `medium`, `bold` and `heavy`. It determines `stroke-width` of icon. | `regular` |
+| `weight`   | One of `ultra-light`, `thin`, `light`, `regular`, `medium`, `bold` and `heavy`. It determines `stroke-width` of icon. | `regular` |
 | `width`  | Width of icon (in pixels).                                                                                            | `32`      |
 | `height` | Height of icon (in pixels).                                                                                           | `32`      |
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ $ npm install --save bytesize-icon-elements
 
     And this is a thin book icon: <icon-book weight="thin"></icon-book>
 
+    And this is a gear icon with sharp edges: <icon-settings style="miter"></icon-book>
+
     Icon size is variable because it's SVG.
 
     This is a big flag icon: <icon-flag size="64"></icon-flag>
@@ -37,6 +39,7 @@ Each icon has below optional properties.
 | Name     | Description                                                                                                           | Default   |
 |----------|-----------------------------------------------------------------------------------------------------------------------|-----------|
 | `weight`   | One of `ultra-light`, `thin`, `light`, `regular`, `medium`, `bold` and `heavy`. It determines `stroke-width` of icon. | `regular` |
+| `style`   | One of `round`, `bevel` and `miter`. It determines `stroke-linejoin` and `stroke-linecap` of icon. | `round` |
 | `size`  | Size (width and height) of icon (in pixels).                                                                                            | `32`      |
 
 ## Development

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
 Custom Elements for Bytesize Icons
 ==================================
 
-This package provides [bytesize-icons](https://github.com/danklammer/bytesize-icons) icons as [CustomElements](https://developers.google.com/web/fundamentals/getting-started/primers/customelements).
-bytesize-icons are lightweight, reasonable set of nice icons with SVG format.
+This package provides icons from [bytesize-icons](https://github.com/danklammer/bytesize-icons) as a [CustomElement](https://developers.google.com/web/fundamentals/getting-started/primers/customelements).
 
+`bytesize-icons` is a lightweight, reasonable set of nice icons in the SVG format.
 
 ## Installation
 
@@ -11,141 +11,46 @@ bytesize-icons are lightweight, reasonable set of nice icons with SVG format.
 $ npm install --save bytesize-icon-elements
 ```
 
-
 ## Usage
 
 ```html
 <html>
   <body>
-    This is search icon: <icon-search></icon-search>
+    This is search icon: <bytesize-icon name="search"></bytesize-icon>
 
-    And this is a thin book icon: <icon-book weight="thin"></icon-book>
+    And this is a thin book icon: <bytesize-icon name="book" weight="thin"></bytesize-icon>
 
-    And this is a gear icon with sharp edges: <icon-settings style="miter"></icon-book>
+    And this is a gear icon with sharp edges: <bytesize-icon name="settings" style="miter"></bytesize-icon>
 
     Icon size is variable because it's SVG.
 
-    This is a big flag icon: <icon-flag size="64"></icon-flag>
+    This is a big flag icon: <bytesize-icon name="flag" size="64"></bytesize-icon>
+
+    <script src="/path/to/bytesize-icon-elements/index.js"></script>
   </body>
-  <script src="/path/to/bytesize-icon-elements/index.js"></script>
 </html>
 ```
 
-Loading `bytesize-icon-elements/index.js` registers `<icon-*>` elements. You can use it in your HTML directly.
+Loading `bytesize-icon-elements/index.js` registers the `<bytesize-icon>` element. You can use it in your HTML directly.
 If you want to use this package with older browsers, you may need [webcomponents.js](https://github.com/webcomponents/webcomponentsjs) as polyfill.
 
-Each icon has below optional properties.
+The following attributes are supported. The `name` attribute is mandatory, the others are optional.
 
 | Name     | Description                                                                                                           | Default   |
 |----------|-----------------------------------------------------------------------------------------------------------------------|-----------|
-| `weight`   | One of `ultra-light`, `thin`, `light`, `regular`, `medium`, `bold` and `heavy`. It determines `stroke-width` of icon. | `regular` |
-| `style`   | One of `round`, `bevel` and `miter`. It determines `stroke-linejoin` and `stroke-linecap` of icon. | `round` |
-| `size`  | Size (width and height) of icon (in pixels).                                                                                            | `32`      |
+| `name`   | See the complete list below. It determines the `id` of the icon symbol. | |
+| `weight`   | One of `ultra-light`, `thin`, `light`, `regular`, `medium`, `bold` and `heavy`. It determines `stroke-width` of the icon. | `regular` |
+| `style`   | One of `round`, `bevel` and `miter`. It determines `stroke-linejoin` and `stroke-linecap` of the icon. | `round` |
+| `size`  | Size (width and height) of the icon (in pixels). | `32` |
 
 ## Development
 
 ```sh
-$ npm install
-# Updates bytesize-icons if needed
+$ npm ci
 $ npm run gen
-$ npm run test
+$ npm test
 ```
 
 ## All Icons
 
-You can see all icons in [bytesize-icons](https://github.com/danklammer/bytesize-icons#grab-n-go) repository page.
-
-- `<icon-activity></icon-activity>`
-- `<icon-alert></icon-alert>`
-- `<icon-archive></icon-archive>`
-- `<icon-arrow-bottom></icon-arrow-bottom>`
-- `<icon-arrow-left></icon-arrow-left>`
-- `<icon-arrow-right></icon-arrow-right>`
-- `<icon-arrow-top></icon-arrow-top>`
-- `<icon-backwards></icon-backwards>`
-- `<icon-bag></icon-bag>`
-- `<icon-ban></icon-ban>`
-- `<icon-bell></icon-bell>`
-- `<icon-book></icon-book>`
-- `<icon-bookmark></icon-bookmark>`
-- `<icon-calendar></icon-calendar>`
-- `<icon-camera></icon-camera>`
-- `<icon-caret-bottom></icon-caret-bottom>`
-- `<icon-caret-left></icon-caret-left>`
-- `<icon-caret-right></icon-caret-right>`
-- `<icon-caret-top></icon-caret-top>`
-- `<icon-cart></icon-cart>`
-- `<icon-checkmark></icon-checkmark>`
-- `<icon-chevron-bottom></icon-chevron-bottom>`
-- `<icon-chevron-left></icon-chevron-left>`
-- `<icon-chevron-right></icon-chevron-right>`
-- `<icon-chevron-top></icon-chevron-top>`
-- `<icon-clipboard></icon-clipboard>`
-- `<icon-clock></icon-clock>`
-- `<icon-close></icon-close>`
-- `<icon-code></icon-code>`
-- `<icon-compose></icon-compose>`
-- `<icon-creditcard></icon-creditcard>`
-- `<icon-desktop></icon-desktop>`
-- `<icon-download></icon-download>`
-- `<icon-edit></icon-edit>`
-- `<icon-eject></icon-eject>`
-- `<icon-ellipsis-horizontal></icon-ellipsis-horizontal>`
-- `<icon-ellipsis-vertical></icon-ellipsis-vertical>`
-- `<icon-end></icon-end>`
-- `<icon-export></icon-export>`
-- `<icon-external></icon-external>`
-- `<icon-eye></icon-eye>`
-- `<icon-file></icon-file>`
-- `<icon-fire></icon-fire>`
-- `<icon-flag></icon-flag>`
-- `<icon-folder></icon-folder>`
-- `<icon-folder-open></icon-folder-open>`
-- `<icon-forwards></icon-forwards>`
-- `<icon-gift></icon-gift>`
-- `<icon-github></icon-github>`
-- `<icon-heart></icon-heart>`
-- `<icon-home></icon-home>`
-- `<icon-import></icon-import>`
-- `<icon-inbox></icon-inbox>`
-- `<icon-info></icon-info>`
-- `<icon-lightning></icon-lightning>`
-- `<icon-link></icon-link>`
-- `<icon-location></icon-location>`
-- `<icon-lock></icon-lock>`
-- `<icon-mail></icon-mail>`
-- `<icon-menu></icon-menu>`
-- `<icon-message></icon-message>`
-- `<icon-microphone></icon-microphone>`
-- `<icon-minus></icon-minus>`
-- `<icon-mobile></icon-mobile>`
-- `<icon-move></icon-move>`
-- `<icon-music></icon-music>`
-- `<icon-mute></icon-mute>`
-- `<icon-options></icon-options>`
-- `<icon-paperclip></icon-paperclip>`
-- `<icon-pause></icon-pause>`
-- `<icon-photo></icon-photo>`
-- `<icon-play></icon-play>`
-- `<icon-plus></icon-plus>`
-- `<icon-portfolio></icon-portfolio>`
-- `<icon-print></icon-print>`
-- `<icon-reload></icon-reload>`
-- `<icon-reply></icon-reply>`
-- `<icon-search></icon-search>`
-- `<icon-send></icon-send>`
-- `<icon-settings></icon-settings>`
-- `<icon-sign-in></icon-sign-in>`
-- `<icon-sign-out></icon-sign-out>`
-- `<icon-star></icon-star>`
-- `<icon-start></icon-start>`
-- `<icon-tag></icon-tag>`
-- `<icon-telephone></icon-telephone>`
-- `<icon-trash></icon-trash>`
-- `<icon-twitter></icon-twitter>`
-- `<icon-unlock></icon-unlock>`
-- `<icon-upload></icon-upload>`
-- `<icon-user></icon-user>`
-- `<icon-video></icon-video>`
-- `<icon-volume></icon-volume>`
-- `<icon-work></icon-work>`
+You can inspect all icons on the [bytesize-icons repository page](https://github.com/danklammer/bytesize-icons#grab-n-go). The following icon names are supported: "activity", "alert", "archive", "arrow-bottom", "arrow-left", "arrow-right", "arrow-top", "backwards", "bag", "ban", "bell", "book", "bookmark", "calendar", "camera", "caret-bottom", "caret-left", "caret-right", "caret-top", "cart", "checkmark", "chevron-bottom", "chevron-left", "chevron-right", "chevron-top", "clipboard", "clock", "close", "code", "compose", "creditcard", "desktop", "download", "edit", "eject", "ellipsis-horizontal", "ellipsis-vertical", "end", "export", "external", "eye", "file", "fire", "flag", "folder", "folder-open", "forwards", "gift", "github", "heart", "home", "import", "inbox", "info", "lightning", "link", "location", "lock", "mail", "menu", "message", "microphone", "minus", "mobile", "move", "music", "mute", "options", "paperclip", "pause", "photo", "play", "plus", "portfolio", "print", "reload", "reply", "search", "send", "settings", "sign-in", "sign-out", "star", "start", "tag", "telephone", "trash", "twitter", "unlock", "upload", "user", "video", "volume", "work".

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ You can see all icons in [bytesize-icons](https://github.com/danklammer/bytesize
 - `<icon-arrow-right></icon-arrow-right>`
 - `<icon-arrow-top></icon-arrow-top>`
 - `<icon-backwards></icon-backwards>`
+- `<icon-bag></icon-bag>`
 - `<icon-ban></icon-ban>`
 - `<icon-bell></icon-bell>`
 - `<icon-book></icon-book>`
@@ -78,11 +79,13 @@ You can see all icons in [bytesize-icons](https://github.com/danklammer/bytesize
 - `<icon-chevron-left></icon-chevron-left>`
 - `<icon-chevron-right></icon-chevron-right>`
 - `<icon-chevron-top></icon-chevron-top>`
+- `<icon-clipboard></icon-clipboard>`
 - `<icon-clock></icon-clock>`
 - `<icon-close></icon-close>`
 - `<icon-code></icon-code>`
 - `<icon-compose></icon-compose>`
 - `<icon-creditcard></icon-creditcard>`
+- `<icon-desktop></icon-desktop>`
 - `<icon-download></icon-download>`
 - `<icon-edit></icon-edit>`
 - `<icon-eject></icon-eject>`
@@ -95,8 +98,8 @@ You can see all icons in [bytesize-icons](https://github.com/danklammer/bytesize
 - `<icon-file></icon-file>`
 - `<icon-fire></icon-fire>`
 - `<icon-flag></icon-flag>`
-- `<icon-folder-open></icon-folder-open>`
 - `<icon-folder></icon-folder>`
+- `<icon-folder-open></icon-folder-open>`
 - `<icon-forwards></icon-forwards>`
 - `<icon-gift></icon-gift>`
 - `<icon-github></icon-github>`
@@ -112,7 +115,10 @@ You can see all icons in [bytesize-icons](https://github.com/danklammer/bytesize
 - `<icon-mail></icon-mail>`
 - `<icon-menu></icon-menu>`
 - `<icon-message></icon-message>`
+- `<icon-microphone></icon-microphone>`
 - `<icon-minus></icon-minus>`
+- `<icon-mobile></icon-mobile>`
+- `<icon-move></icon-move>`
 - `<icon-music></icon-music>`
 - `<icon-mute></icon-mute>`
 - `<icon-options></icon-options>`
@@ -128,9 +134,12 @@ You can see all icons in [bytesize-icons](https://github.com/danklammer/bytesize
 - `<icon-search></icon-search>`
 - `<icon-send></icon-send>`
 - `<icon-settings></icon-settings>`
+- `<icon-sign-in></icon-sign-in>`
+- `<icon-sign-out></icon-sign-out>`
 - `<icon-star></icon-star>`
 - `<icon-start></icon-start>`
 - `<icon-tag></icon-tag>`
+- `<icon-telephone></icon-telephone>`
 - `<icon-trash></icon-trash>`
 - `<icon-twitter></icon-twitter>`
 - `<icon-unlock></icon-unlock>`

--- a/index.html
+++ b/index.html
@@ -3,15 +3,15 @@
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes" />
-    <title></title>
+    <title>Test BytesizeIcon Element</title>
   </head>
   <style>
     table, td, th {
       border: 1px #d0d2d0 solid;
       border-collapse: collapse;
     }
-    th {
-      padding: 0 8px;
+    th, td {
+      padding: .5em;
     }
     td {
       text-align: center;
@@ -19,40 +19,40 @@
   </style>
   <body>
     <table id="contents"></table>
-  </body>
-  <script src="index.js"></script>
-  <script>
-    const main = document.getElementById('contents');
-    const weights = ['ultra-light', 'thin', 'light', 'regular', 'medium', 'bold', 'heavy'];
-    const styles = ['bevel', 'miter'];
-    {
-      const tr = document.createElement('tr');
-      tr.appendChild(document.createElement('th'));
-      weights.forEach(createTableHeader);
-      styles.forEach(createTableHeader);
-      main.appendChild(tr);
-      function createTableHeader(title) {
-        const th = document.createElement('th');
-        th.innerText = title;
-        tr.appendChild(th);
-      }
-    }
-    window.BytesizeIcons.ICON_NAMES.forEach(n => {
-      const tr = document.createElement('tr');
-      const name = document.createElement('th');
-      name.innerText = n;
-      tr.appendChild(name);
-      weights.forEach(createTableCell);
-      styles.forEach(createTableCell.bind(null, 'regular'));
-      main.appendChild(tr);
-      function createTableCell(weight, style) {
-        const td = document.createElement('td');
-        if (!style) {
-          style = 'round';
+    <script src="index.js"></script>
+    <script>
+      const main = document.getElementById('contents');
+      const weights = ['ultra-light', 'thin', 'light', 'regular', 'medium', 'bold', 'heavy'];
+      const styles = ['bevel', 'miter'];
+      {
+        const tr = document.createElement('tr');
+        tr.appendChild(document.createElement('th'));
+        weights.forEach(createTableHeader);
+        styles.forEach(createTableHeader);
+        main.appendChild(tr);
+        function createTableHeader(title) {
+          const th = document.createElement('th');
+          th.innerText = title;
+          tr.appendChild(th);
         }
-        td.innerHTML = `<icon-${n} weight="${weight}" style="${style}"></icon-${n}>`;
-        tr.appendChild(td);
       }
-    });
-  </script>
+      BytesizeIcon.names.forEach(n => {
+        const tr = document.createElement('tr');
+        const name = document.createElement('th');
+        name.innerText = n;
+        tr.appendChild(name);
+        weights.forEach(createTableCell);
+        styles.forEach(createTableCell.bind(null, 'regular'));
+        main.appendChild(tr);
+        function createTableCell(weight, style) {
+          const td = document.createElement('td');
+          if (!style) {
+            style = 'round';
+          }
+          td.innerHTML = `<bytesize-icon name="${n}" weight="${weight}" style="${style}"></bytesize-icon>`;
+          tr.appendChild(td);
+        }
+      });
+    </script>
+  </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -24,27 +24,35 @@
   <script>
     const main = document.getElementById('contents');
     const weights = ['ultra-light', 'thin', 'light', 'regular', 'medium', 'bold', 'heavy'];
+    const styles = ['bevel', 'miter'];
     {
       const tr = document.createElement('tr');
       tr.appendChild(document.createElement('th'));
-      weights.forEach(t => {
-        const th = document.createElement('th');
-        th.innerText = t;
-        tr.appendChild(th);
-      });
+      weights.forEach(createTableHeader);
+      styles.forEach(createTableHeader);
       main.appendChild(tr);
+      function createTableHeader(title) {
+        const th = document.createElement('th');
+        th.innerText = title;
+        tr.appendChild(th);
+      }
     }
     window.BytesizeIcons.ICON_NAMES.forEach(n => {
       const tr = document.createElement('tr');
       const name = document.createElement('th');
       name.innerText = n;
       tr.appendChild(name);
-      weights.forEach(t => {
-        const td = document.createElement('td');
-        td.innerHTML = `<icon-${n} weight="${t}"></icon-${n}>`;
-        tr.appendChild(td);
-      });
+      weights.forEach(createTableCell);
+      styles.forEach(createTableCell.bind(null, 'regular'));
       main.appendChild(tr);
+      function createTableCell(weight, style) {
+        const td = document.createElement('td');
+        if (!style) {
+          style = 'round';
+        }
+        td.innerHTML = `<icon-${n} weight="${weight}" style="${style}"></icon-${n}>`;
+        tr.appendChild(td);
+      }
     });
   </script>
 </html>

--- a/index.html
+++ b/index.html
@@ -23,11 +23,11 @@
   <script src="index.js"></script>
   <script>
     const main = document.getElementById('contents');
-    const types = ['ultra-light', 'thin', 'light', 'regular', 'medium', 'bold', 'heavy'];
+    const weights = ['ultra-light', 'thin', 'light', 'regular', 'medium', 'bold', 'heavy'];
     {
       const tr = document.createElement('tr');
       tr.appendChild(document.createElement('th'));
-      types.forEach(t => {
+      weights.forEach(t => {
         const th = document.createElement('th');
         th.innerText = t;
         tr.appendChild(th);
@@ -39,9 +39,9 @@
       const name = document.createElement('th');
       name.innerText = n;
       tr.appendChild(name);
-      types.forEach(t => {
+      weights.forEach(t => {
         const td = document.createElement('td');
-        td.innerHTML = `<icon-${n} type="${t}"></icon-${n}>`;
+        td.innerHTML = `<icon-${n} weight="${t}"></icon-${n}>`;
         tr.appendChild(td);
       });
       main.appendChild(tr);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,965 @@
+{
+  "name": "bytesize-icon-elements",
+  "version": "1.0.3",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@babel/code-frame": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.0.0.tgz",
+      "integrity": "sha512-OfC2uemaknXr87bdLUkWog7nYuliM9Ij5HUcajsVcMCpQrcLmtxRbVFTIqmcSkSeYRBFBRxs2FiUqFJDLdiebA==",
+      "dev": true,
+      "requires": {
+        "@babel/highlight": "^7.0.0"
+      }
+    },
+    "@babel/highlight": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.0.0.tgz",
+      "integrity": "sha512-UFMC4ZeFC48Tpvj7C8UgLvtkaUuovQX+5xNWrsIoMG8o2z+XFKjKaN9iVmS84dPwVN00W4wPmqvYoZF3EGAsfw==",
+      "dev": true,
+      "requires": {
+        "chalk": "^2.0.0",
+        "esutils": "^2.0.2",
+        "js-tokens": "^4.0.0"
+      }
+    },
+    "acorn": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+      "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
+      "dev": true
+    },
+    "acorn-jsx": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.0.1.tgz",
+      "integrity": "sha512-HJ7CfNHrfJLlNTzIEUTj43LNWGkqpRLxm3YjAlcD0ACydk9XynzYsCBHxut+iqt+1aBXkx9UP/w/ZqMr13XIzg==",
+      "dev": true
+    },
+    "ajv": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.10.0.tgz",
+      "integrity": "sha512-nffhOpkymDECQyR0mnsUtoCE8RlX38G0rYP+wgLWFyZuUyuuojSSvi/+euOiQBIn63whYwYVIIH1TvE3tu4OEg==",
+      "dev": true,
+      "requires": {
+        "fast-deep-equal": "^2.0.1",
+        "fast-json-stable-stringify": "^2.0.0",
+        "json-schema-traverse": "^0.4.1",
+        "uri-js": "^4.2.2"
+      }
+    },
+    "ansi-escapes": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-escapes/-/ansi-escapes-3.2.0.tgz",
+      "integrity": "sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==",
+      "dev": true
+    },
+    "ansi-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+      "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=",
+      "dev": true
+    },
+    "ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "requires": {
+        "color-convert": "^1.9.0"
+      }
+    },
+    "argparse": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
+      "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
+      "dev": true,
+      "requires": {
+        "sprintf-js": "~1.0.2"
+      }
+    },
+    "astral-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
+      "integrity": "sha512-+Ryf6g3BKoRc7jfp7ad8tM4TtMiaWvbF/1/sQcZPkkS7ag3D5nMBCe2UfOTONtAkaG0tO0ij3C5Lwmf1EiyjHg==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "bytesize-icons": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/bytesize-icons/-/bytesize-icons-1.3.0.tgz",
+      "integrity": "sha1-JD1xyJQoNWybmAhMXrQyrKT2Ask=",
+      "dev": true
+    },
+    "callsites": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.0.0.tgz",
+      "integrity": "sha512-tWnkwu9YEq2uzlBDI4RcLn8jrFvF9AOi8PxDNU3hZZjJcjkcRAq3vCI+vZcg1SuxISDYe86k9VZFwAxDiJGoAw==",
+      "dev": true
+    },
+    "chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      }
+    },
+    "chardet": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
+      "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
+      "dev": true
+    },
+    "cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "requires": {
+        "restore-cursor": "^2.0.0"
+      }
+    },
+    "cli-width": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/cli-width/-/cli-width-2.2.0.tgz",
+      "integrity": "sha1-/xnt6Kml5XkyQUewwR8PvLq+1jk=",
+      "dev": true
+    },
+    "color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "requires": {
+        "color-name": "1.1.3"
+      }
+    },
+    "color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "cross-spawn": {
+      "version": "6.0.5",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
+      "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
+      "dev": true,
+      "requires": {
+        "nice-try": "^1.0.4",
+        "path-key": "^2.0.1",
+        "semver": "^5.5.0",
+        "shebang-command": "^1.2.0",
+        "which": "^1.2.9"
+      }
+    },
+    "debug": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+      "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+      "dev": true,
+      "requires": {
+        "ms": "^2.1.1"
+      }
+    },
+    "deep-is": {
+      "version": "0.1.3",
+      "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
+      "integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+      "dev": true
+    },
+    "doctrine": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-3.0.0.tgz",
+      "integrity": "sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==",
+      "dev": true,
+      "requires": {
+        "esutils": "^2.0.2"
+      }
+    },
+    "emoji-regex": {
+      "version": "7.0.3",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-7.0.3.tgz",
+      "integrity": "sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==",
+      "dev": true
+    },
+    "escape-string-regexp": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
+    },
+    "eslint": {
+      "version": "5.15.3",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.3.tgz",
+      "integrity": "sha512-vMGi0PjCHSokZxE0NLp2VneGw5sio7SSiDNgIUn2tC0XkWJRNOIoHIg3CliLVfXnJsiHxGAYrkw0PieAu8+KYQ==",
+      "dev": true,
+      "requires": {
+        "@babel/code-frame": "^7.0.0",
+        "ajv": "^6.9.1",
+        "chalk": "^2.1.0",
+        "cross-spawn": "^6.0.5",
+        "debug": "^4.0.1",
+        "doctrine": "^3.0.0",
+        "eslint-scope": "^4.0.3",
+        "eslint-utils": "^1.3.1",
+        "eslint-visitor-keys": "^1.0.0",
+        "espree": "^5.0.1",
+        "esquery": "^1.0.1",
+        "esutils": "^2.0.2",
+        "file-entry-cache": "^5.0.1",
+        "functional-red-black-tree": "^1.0.1",
+        "glob": "^7.1.2",
+        "globals": "^11.7.0",
+        "ignore": "^4.0.6",
+        "import-fresh": "^3.0.0",
+        "imurmurhash": "^0.1.4",
+        "inquirer": "^6.2.2",
+        "js-yaml": "^3.12.0",
+        "json-stable-stringify-without-jsonify": "^1.0.1",
+        "levn": "^0.3.0",
+        "lodash": "^4.17.11",
+        "minimatch": "^3.0.4",
+        "mkdirp": "^0.5.1",
+        "natural-compare": "^1.4.0",
+        "optionator": "^0.8.2",
+        "path-is-inside": "^1.0.2",
+        "progress": "^2.0.0",
+        "regexpp": "^2.0.1",
+        "semver": "^5.5.1",
+        "strip-ansi": "^4.0.0",
+        "strip-json-comments": "^2.0.1",
+        "table": "^5.2.3",
+        "text-table": "^0.2.0"
+      }
+    },
+    "eslint-scope": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-4.0.3.tgz",
+      "integrity": "sha512-p7VutNr1O/QrxysMo3E45FjYDTeXBy0iTltPFNSqKAIfjDSXC+4dj+qfyuD8bfAXrW/y6lW3O76VaYNPKfpKrg==",
+      "dev": true,
+      "requires": {
+        "esrecurse": "^4.1.0",
+        "estraverse": "^4.1.1"
+      }
+    },
+    "eslint-utils": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.3.1.tgz",
+      "integrity": "sha512-Z7YjnIldX+2XMcjr7ZkgEsOj/bREONV60qYeB/bjMAqqqZ4zxKyWX+BOUkdmRmA9riiIPVvo5x86m5elviOk0Q==",
+      "dev": true
+    },
+    "eslint-visitor-keys": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-visitor-keys/-/eslint-visitor-keys-1.0.0.tgz",
+      "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ==",
+      "dev": true
+    },
+    "espree": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/espree/-/espree-5.0.1.tgz",
+      "integrity": "sha512-qWAZcWh4XE/RwzLJejfcofscgMc9CamR6Tn1+XRXNzrvUSSbiAjGOI/fggztjIi7y9VLPqnICMIPiGyr8JaZ0A==",
+      "dev": true,
+      "requires": {
+        "acorn": "^6.0.7",
+        "acorn-jsx": "^5.0.0",
+        "eslint-visitor-keys": "^1.0.0"
+      }
+    },
+    "esprima": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
+      "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+      "dev": true
+    },
+    "esquery": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.1.tgz",
+      "integrity": "sha512-SmiyZ5zIWH9VM+SRUReLS5Q8a7GxtRdxEBVZpm98rJM7Sb+A9DVCndXfkeFUd3byderg+EbDkfnevfCwynWaNA==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.0.0"
+      }
+    },
+    "esrecurse": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.1.tgz",
+      "integrity": "sha512-64RBB++fIOAXPw3P9cy89qfMlvZEXZkqqJkjqqXIvzP5ezRZjW+lPWjw35UX/3EhUPFYbg5ER4JYgDw4007/DQ==",
+      "dev": true,
+      "requires": {
+        "estraverse": "^4.1.0"
+      }
+    },
+    "estraverse": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.2.0.tgz",
+      "integrity": "sha1-De4/7TH81GlhjOc0IJn8GvoL2xM=",
+      "dev": true
+    },
+    "esutils": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
+    },
+    "external-editor": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
+      "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+      "dev": true,
+      "requires": {
+        "chardet": "^0.7.0",
+        "iconv-lite": "^0.4.24",
+        "tmp": "^0.0.33"
+      }
+    },
+    "fast-deep-equal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-2.0.1.tgz",
+      "integrity": "sha1-ewUhjd+WZ79/Nwv3/bLLFf3Qqkk=",
+      "dev": true
+    },
+    "fast-json-stable-stringify": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
+    },
+    "fast-levenshtein": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
+      "integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+      "dev": true
+    },
+    "figures": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
+      "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
+      "dev": true,
+      "requires": {
+        "escape-string-regexp": "^1.0.5"
+      }
+    },
+    "file-entry-cache": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-5.0.1.tgz",
+      "integrity": "sha512-bCg29ictuBaKUwwArK4ouCaqDgLZcysCFLmM/Yn/FDoqndh/9vNuQfXRDvTuXKLxfD/JtZQGKFT8MGcJBK644g==",
+      "dev": true,
+      "requires": {
+        "flat-cache": "^2.0.1"
+      }
+    },
+    "flat-cache": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-2.0.1.tgz",
+      "integrity": "sha512-LoQe6yDuUMDzQAEH8sgmh4Md6oZnc/7PjtwjNFSzveXqSHt6ka9fPBuso7IGf9Rz4uqnSnWiFH2B/zj24a5ReA==",
+      "dev": true,
+      "requires": {
+        "flatted": "^2.0.0",
+        "rimraf": "2.6.3",
+        "write": "1.0.3"
+      }
+    },
+    "flatted": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.0.tgz",
+      "integrity": "sha512-R+H8IZclI8AAkSBRQJLVOsxwAoHd6WC40b4QTNWIjzAa6BXOBfQcM587MXDTVPeYaopFNWHUFLx7eNmHDSxMWg==",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "functional-red-black-tree": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/functional-red-black-tree/-/functional-red-black-tree-1.0.1.tgz",
+      "integrity": "sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.3",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.3.tgz",
+      "integrity": "sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "globals": {
+      "version": "11.11.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-11.11.0.tgz",
+      "integrity": "sha512-WHq43gS+6ufNOEqlrDBxVEbb8ntfXrfAUU2ZOpCxrBdGKW3gyv8mCxAfIBD0DroPKGrJ2eSsXsLtY9MPntsyTw==",
+      "dev": true
+    },
+    "has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true
+    },
+    "iconv-lite": {
+      "version": "0.4.24",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
+      "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
+      "dev": true,
+      "requires": {
+        "safer-buffer": ">= 2.1.2 < 3"
+      }
+    },
+    "ignore": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
+      "integrity": "sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==",
+      "dev": true
+    },
+    "import-fresh": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.0.0.tgz",
+      "integrity": "sha512-pOnA9tfM3Uwics+SaBLCNyZZZbK+4PTu0OPZtLlMIrv17EdBoC15S9Kn8ckJ9TZTyKb3ywNE5y1yeDxxGA7nTQ==",
+      "dev": true,
+      "requires": {
+        "parent-module": "^1.0.0",
+        "resolve-from": "^4.0.0"
+      }
+    },
+    "imurmurhash": {
+      "version": "0.1.4",
+      "resolved": "https://registry.npmjs.org/imurmurhash/-/imurmurhash-0.1.4.tgz",
+      "integrity": "sha1-khi5srkoojixPcT7a21XbyMUU+o=",
+      "dev": true
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.3.tgz",
+      "integrity": "sha1-Yzwsg+PaQqUC9SRmAiSA9CCCYd4=",
+      "dev": true
+    },
+    "inquirer": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.2.2.tgz",
+      "integrity": "sha512-Z2rREiXA6cHRR9KBOarR3WuLlFzlIfAEIiB45ll5SSadMg7WqOh1MKEjjndfuH5ewXdixWCxqnVfGOQzPeiztA==",
+      "dev": true,
+      "requires": {
+        "ansi-escapes": "^3.2.0",
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-width": "^2.0.0",
+        "external-editor": "^3.0.3",
+        "figures": "^2.0.0",
+        "lodash": "^4.17.11",
+        "mute-stream": "0.0.7",
+        "run-async": "^2.2.0",
+        "rxjs": "^6.4.0",
+        "string-width": "^2.1.0",
+        "strip-ansi": "^5.0.0",
+        "through": "^2.3.6"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "is-fullwidth-code-point": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-2.0.0.tgz",
+      "integrity": "sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=",
+      "dev": true
+    },
+    "is-promise": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/is-promise/-/is-promise-2.1.0.tgz",
+      "integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
+      "dev": true
+    },
+    "isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=",
+      "dev": true
+    },
+    "js-tokens": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+      "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true
+    },
+    "js-yaml": {
+      "version": "3.12.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.12.2.tgz",
+      "integrity": "sha512-QHn/Lh/7HhZ/Twc7vJYQTkjuCa0kaCcDcjK5Zlk2rvnUpy7DxMJ23+Jc2dcyvltwQVg1nygAVlB2oRDFHoRS5Q==",
+      "dev": true,
+      "requires": {
+        "argparse": "^1.0.7",
+        "esprima": "^4.0.0"
+      }
+    },
+    "json-schema-traverse": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
+    },
+    "json-stable-stringify-without-jsonify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
+      "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
+      "dev": true
+    },
+    "levn": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
+      "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2"
+      }
+    },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==",
+      "dev": true
+    },
+    "mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "0.0.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+      "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0=",
+      "dev": true
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "dev": true,
+      "requires": {
+        "minimist": "0.0.8"
+      }
+    },
+    "ms": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
+      "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
+      "dev": true
+    },
+    "mute-stream": {
+      "version": "0.0.7",
+      "resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
+      "integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+      "dev": true
+    },
+    "natural-compare": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
+      "integrity": "sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=",
+      "dev": true
+    },
+    "nice-try": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/nice-try/-/nice-try-1.0.5.tgz",
+      "integrity": "sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==",
+      "dev": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "requires": {
+        "mimic-fn": "^1.0.0"
+      }
+    },
+    "optionator": {
+      "version": "0.8.2",
+      "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
+      "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
+      "dev": true,
+      "requires": {
+        "deep-is": "~0.1.3",
+        "fast-levenshtein": "~2.0.4",
+        "levn": "~0.3.0",
+        "prelude-ls": "~1.1.2",
+        "type-check": "~0.3.2",
+        "wordwrap": "~1.0.0"
+      }
+    },
+    "os-tmpdir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
+      "integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+      "dev": true
+    },
+    "parent-module": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.0.tgz",
+      "integrity": "sha512-8Mf5juOMmiE4FcmzYc4IaiS9L3+9paz2KOiXzkRviCP6aDmN49Hz6EMWz0lGNp9pX80GvvAuLADtyGfW/Em3TA==",
+      "dev": true,
+      "requires": {
+        "callsites": "^3.0.0"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-is-inside": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/path-is-inside/-/path-is-inside-1.0.2.tgz",
+      "integrity": "sha1-NlQX3t5EQw0cEa9hAn+s8HS9/FM=",
+      "dev": true
+    },
+    "path-key": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
+      "integrity": "sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=",
+      "dev": true
+    },
+    "prelude-ls": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
+      "integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+      "dev": true
+    },
+    "progress": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
+      "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+      "dev": true
+    },
+    "punycode": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
+    },
+    "regexpp": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-2.0.1.tgz",
+      "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw==",
+      "dev": true
+    },
+    "resolve-from": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
+      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
+      "dev": true
+    },
+    "restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "requires": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      }
+    },
+    "rimraf": {
+      "version": "2.6.3",
+      "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.3.tgz",
+      "integrity": "sha512-mwqeW5XsA2qAejG46gYdENaxXjx9onRNCfn7L0duuP4hCuTIi/QO7PDK07KJfp1d+izWPrzEJDcSqBa0OZQriA==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.1.3"
+      }
+    },
+    "run-async": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
+      "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
+      "dev": true,
+      "requires": {
+        "is-promise": "^2.1.0"
+      }
+    },
+    "rxjs": {
+      "version": "6.4.0",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.4.0.tgz",
+      "integrity": "sha512-Z9Yfa11F6B9Sg/BK9MnqnQ+aQYicPLtilXBp2yUtDt2JRCE0h26d33EnfO3ZxoNxG0T92OUucP3Ct7cpfkdFfw==",
+      "dev": true,
+      "requires": {
+        "tslib": "^1.9.0"
+      }
+    },
+    "safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true
+    },
+    "semver": {
+      "version": "5.6.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
+      "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg==",
+      "dev": true
+    },
+    "shebang-command": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
+      "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
+      "dev": true,
+      "requires": {
+        "shebang-regex": "^1.0.0"
+      }
+    },
+    "shebang-regex": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-1.0.0.tgz",
+      "integrity": "sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=",
+      "dev": true
+    },
+    "signal-exit": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
+      "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0=",
+      "dev": true
+    },
+    "slice-ansi": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-2.1.0.tgz",
+      "integrity": "sha512-Qu+VC3EwYLldKa1fCxuuvULvSJOKEgk9pi8dZeCVK7TqBfUNTH4sFkk4joj8afVSfAYgJoSOetjx9QWOJ5mYoQ==",
+      "dev": true,
+      "requires": {
+        "ansi-styles": "^3.2.0",
+        "astral-regex": "^1.0.0",
+        "is-fullwidth-code-point": "^2.0.0"
+      }
+    },
+    "sprintf-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true,
+      "requires": {
+        "is-fullwidth-code-point": "^2.0.0",
+        "strip-ansi": "^4.0.0"
+      }
+    },
+    "strip-ansi": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+      "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+      "dev": true,
+      "requires": {
+        "ansi-regex": "^3.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "dev": true
+    },
+    "supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "requires": {
+        "has-flag": "^3.0.0"
+      }
+    },
+    "table": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/table/-/table-5.2.3.tgz",
+      "integrity": "sha512-N2RsDAMvDLvYwFcwbPyF3VmVSSkuF+G1e+8inhBLtHpvwXGw4QRPEZhihQNeEN0i1up6/f6ObCJXNdlRG3YVyQ==",
+      "dev": true,
+      "requires": {
+        "ajv": "^6.9.1",
+        "lodash": "^4.17.11",
+        "slice-ansi": "^2.1.0",
+        "string-width": "^3.0.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "string-width": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/string-width/-/string-width-3.1.0.tgz",
+          "integrity": "sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==",
+          "dev": true,
+          "requires": {
+            "emoji-regex": "^7.0.1",
+            "is-fullwidth-code-point": "^2.0.0",
+            "strip-ansi": "^5.1.0"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        }
+      }
+    },
+    "text-table": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
+      "integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+      "dev": true
+    },
+    "through": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
+      "integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
+      "dev": true
+    },
+    "tmp": {
+      "version": "0.0.33",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
+      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
+      "dev": true,
+      "requires": {
+        "os-tmpdir": "~1.0.2"
+      }
+    },
+    "tslib": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.9.3.tgz",
+      "integrity": "sha512-4krF8scpejhaOgqzBEcGM7yDIEfi0/8+8zDRZhNZZ2kjmHJ4hv3zCbQWxoJGz1iw5U0Jl0nma13xzHXcncMavQ==",
+      "dev": true
+    },
+    "type-check": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
+      "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+      "dev": true,
+      "requires": {
+        "prelude-ls": "~1.1.2"
+      }
+    },
+    "uri-js": {
+      "version": "4.2.2",
+      "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
+      "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
+      "requires": {
+        "punycode": "^2.1.0"
+      }
+    },
+    "which": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/which/-/which-1.3.1.tgz",
+      "integrity": "sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==",
+      "dev": true,
+      "requires": {
+        "isexe": "^2.0.0"
+      }
+    },
+    "wordwrap": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+      "integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus=",
+      "dev": true
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    },
+    "write": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/write/-/write-1.0.3.tgz",
+      "integrity": "sha512-/lg70HAjtkUgWPVZhZcm+T4hkL8Zbtp1nFNOn3lRrxnlv50SRBv7cR7RqR+GMsd3hUXy9hWBo4CHTbFTcOYwig==",
+      "dev": true,
+      "requires": {
+        "mkdirp": "^0.5.1"
+      }
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "LICENSE"
   ],
   "devDependencies": {
-    "bytesize-icons": "^1.1.0",
-    "eslint": "^3.10.2"
+    "bytesize-icons": "^1.3.0",
+    "eslint": "^5.15.3"
   }
 }

--- a/scripts/README_template.md
+++ b/scripts/README_template.md
@@ -1,9 +1,7 @@
 Custom Elements for Bytesize Icons
 ==================================
 
-This package provides [bytesize-icons](https://github.com/danklammer/bytesize-icons) icons as [CustomElements](https://developers.google.com/web/fundamentals/getting-started/primers/customelements).
-bytesize-icons are lightweight, reasonable set of nice icons with SVG format.
-
+This package provides icons from [bytesize-icons](https://github.com/danklammer/bytesize-icons) as a [CustomElement](https://developers.google.com/web/fundamentals/getting-started/primers/customelements). The bytesize-icons package contains a lightweight, reasonable set of nice icons in the SVG format.
 
 ## Installation
 
@@ -11,47 +9,46 @@ bytesize-icons are lightweight, reasonable set of nice icons with SVG format.
 $ npm install --save bytesize-icon-elements
 ```
 
-
 ## Usage
 
 ```html
 <html>
   <body>
-    This is search icon: <icon-search></icon-search>
+    This is search icon: <bytesize-icon name="search"></bytesize-icon>
 
-    And this is a thin book icon: <icon-book weight="thin"></icon-book>
+    And this is a thin book icon: <bytesize-icon name="book" weight="thin"></bytesize-icon>
 
-    And this is a gear icon with sharp edges: <icon-settings style="miter"></icon-book>
+    And this is a gear icon with sharp edges: <bytesize-icon name="settings" style="miter"></bytesize-icon>
 
     Icon size is variable because it's SVG.
 
-    This is a big flag icon: <icon-flag size="64"></icon-flag>
+    This is a big flag icon: <bytesize-icon name="flag" size="64"></bytesize-icon>
+
+    <script src="/path/to/bytesize-icon-elements/index.js"></script>
   </body>
-  <script src="/path/to/bytesize-icon-elements/index.js"></script>
 </html>
 ```
 
-Loading `bytesize-icon-elements/index.js` registers `<icon-*>` elements. You can use it in your HTML directly.
+Loading `bytesize-icon-elements/index.js` registers the `<bytesize-icon>` element. You can use it in your HTML directly.
 If you want to use this package with older browsers, you may need [webcomponents.js](https://github.com/webcomponents/webcomponentsjs) as polyfill.
 
-Each icon has below optional properties.
+The following attributes are supported. The `name` attribute is mandatory, the others are optional.
 
 | Name     | Description                                                                                                           | Default   |
 |----------|-----------------------------------------------------------------------------------------------------------------------|-----------|
-| `weight`   | One of `ultra-light`, `thin`, `light`, `regular`, `medium`, `bold` and `heavy`. It determines `stroke-width` of icon. | `regular` |
-| `style`   | One of `round`, `bevel` and `miter`. It determines `stroke-linejoin` and `stroke-linecap` of icon. | `round` |
-| `size`  | Size (width and height) of icon (in pixels).                                                                                            | `32`      |
+| `name`   | See the complete list below. It determines the `id` of the icon symbol. | |
+| `weight`   | One of `ultra-light`, `thin`, `light`, `regular`, `medium`, `bold` and `heavy`. It determines `stroke-width` of the icon. | `regular` |
+| `style`   | One of `round`, `bevel` and `miter`. It determines `stroke-linejoin` and `stroke-linecap` of the icon. | `round` |
+| `size`  | Size (width and height) of the icon (in pixels). | `32` |
 
 ## Development
 
 ```sh
-$ npm install
-# Updates bytesize-icons if needed
+$ npm ci
 $ npm run gen
-$ npm run test
+$ npm test
 ```
 
 ## All Icons
 
-You can see all icons in [bytesize-icons](https://github.com/danklammer/bytesize-icons#grab-n-go) repository page.
-
+You can inspect all icons on the [bytesize-icons repository page](https://github.com/danklammer/bytesize-icons#grab-n-go). The following icon names are supported:

--- a/scripts/README_template.md
+++ b/scripts/README_template.md
@@ -23,7 +23,7 @@ $ npm install --save bytesize-icon-elements
 
     Icon size is variable because it's SVG.
 
-    This is a big flag icon: <icon-flag width="64" height="64"></icon-flag>
+    This is a big flag icon: <icon-flag size="64"></icon-flag>
   </body>
   <script src="/path/to/bytesize-icon-elements/index.js"></script>
 </html>
@@ -37,9 +37,7 @@ Each icon has below optional properties.
 | Name     | Description                                                                                                           | Default   |
 |----------|-----------------------------------------------------------------------------------------------------------------------|-----------|
 | `weight`   | One of `ultra-light`, `thin`, `light`, `regular`, `medium`, `bold` and `heavy`. It determines `stroke-width` of icon. | `regular` |
-| `width`  | Width of icon (in pixels).                                                                                            | `32`      |
-| `height` | Height of icon (in pixels).                                                                                           | `32`      |
-
+| `size`  | Size (width and height) of icon (in pixels).                                                                                            | `32`      |
 
 ## Development
 

--- a/scripts/README_template.md
+++ b/scripts/README_template.md
@@ -19,7 +19,7 @@ $ npm install --save bytesize-icon-elements
   <body>
     This is search icon: <icon-search></icon-search>
 
-    And this is a thin book icon: <icon-book type="thin"></icon-book>
+    And this is a thin book icon: <icon-book weight="thin"></icon-book>
 
     Icon size is variable because it's SVG.
 
@@ -36,7 +36,7 @@ Each icon has below optional properties.
 
 | Name     | Description                                                                                                           | Default   |
 |----------|-----------------------------------------------------------------------------------------------------------------------|-----------|
-| `type`   | One of `ultra-light`, `thin`, `light`, `regular`, `medium`, `bold` and `heavy`. It determines `stroke-width` of icon. | `regular` |
+| `weight`   | One of `ultra-light`, `thin`, `light`, `regular`, `medium`, `bold` and `heavy`. It determines `stroke-width` of icon. | `regular` |
 | `width`  | Width of icon (in pixels).                                                                                            | `32`      |
 | `height` | Height of icon (in pixels).                                                                                           | `32`      |
 

--- a/scripts/README_template.md
+++ b/scripts/README_template.md
@@ -21,6 +21,8 @@ $ npm install --save bytesize-icon-elements
 
     And this is a thin book icon: <icon-book weight="thin"></icon-book>
 
+    And this is a gear icon with sharp edges: <icon-settings style="miter"></icon-book>
+
     Icon size is variable because it's SVG.
 
     This is a big flag icon: <icon-flag size="64"></icon-flag>
@@ -37,6 +39,7 @@ Each icon has below optional properties.
 | Name     | Description                                                                                                           | Default   |
 |----------|-----------------------------------------------------------------------------------------------------------------------|-----------|
 | `weight`   | One of `ultra-light`, `thin`, `light`, `regular`, `medium`, `bold` and `heavy`. It determines `stroke-width` of icon. | `regular` |
+| `style`   | One of `round`, `bevel` and `miter`. It determines `stroke-linejoin` and `stroke-linecap` of icon. | `round` |
 | `size`  | Size (width and height) of icon (in pixels).                                                                                            | `32`      |
 
 ## Development

--- a/scripts/generate.rb
+++ b/scripts/generate.rb
@@ -38,7 +38,7 @@ test = File.join(__dir__, '..', 'icon_names.js')
 puts <<-JS
 (function() {
   window.BytesizeIcons = {};
-  const typeToWidth = {
+  const weights = {
     'ultra-light': '1.5625%',
     thin: '3.125%',
     light: '4.6875%',
@@ -63,9 +63,9 @@ puts <<-JS
     } else {
       child.setAttribute('height', '32');
     }
-    const t = self.getAttribute('type');
-    if (t && typeToWidth[t]) {
-      child.setAttribute('stroke-width', typeToWidth[t]);
+    const weight = weights[self.getAttribute('weight')];
+    if (weight) {
+      child.setAttribute('stroke-width', weight);
     }
   }
 

--- a/scripts/generate.rb
+++ b/scripts/generate.rb
@@ -47,6 +47,20 @@ puts <<-JS
     bold: '9.375%',
     heavy: '10.9375%'
   };
+  const styles = {
+    round: {
+      linejoin: 'round',
+      linecap: 'round',
+    },
+    bevel: {
+      linejoin: 'bevel',
+      linecap: 'butt',
+    },
+    miter: {
+      linejoin: 'miter',
+      linecap: 'butt',
+    }
+  };
 
   function setupIconElement(self, html) {
     self.innerHTML = html;
@@ -57,6 +71,11 @@ puts <<-JS
     const weight = weights[self.getAttribute('weight')];
     if (weight) {
       child.setAttribute('stroke-width', weight);
+    }
+    const style = styles[self.getAttribute('style')];
+    if (style) {
+      child.setAttribute('stroke-linejoin', style.linejoin);
+      child.setAttribute('stroke-linecap', style.linecap);
     }
   }
 

--- a/scripts/generate.rb
+++ b/scripts/generate.rb
@@ -51,18 +51,9 @@ puts <<-JS
   function setupIconElement(self, html) {
     self.innerHTML = html;
     const child =  self.getElementsByTagName('svg')[0];
-    const w = self.getAttribute('width');
-    if (w) {
-      child.setAttribute('width', w);
-    } else {
-      child.setAttribute('width', '32');
-    }
-    const h = self.getAttribute('height');
-    if (h) {
-      child.setAttribute('height', w);
-    } else {
-      child.setAttribute('height', '32');
-    }
+    const size = self.getAttribute('size') || '32';
+    child.setAttribute('width', size);
+    child.setAttribute('height', size);
     const weight = weights[self.getAttribute('weight')];
     if (weight) {
       child.setAttribute('stroke-width', weight);

--- a/scripts/readme_gen.rb
+++ b/scripts/readme_gen.rb
@@ -5,6 +5,7 @@ template = File.join(__dir__, 'README_template.md')
 readme = File.join(__dir__, '..', 'README_template.md')
 list = Dir.glob(File.join(icons, '*.svg'))
   .map{|f| File.basename(f, '.svg')}
+  .sort
   .map{|n| "- `<icon-#{n}></icon-#{n}>`"}
   .join("\n")
 puts(File.read(template) + list)

--- a/scripts/readme_gen.rb
+++ b/scripts/readme_gen.rb
@@ -3,9 +3,8 @@
 icons = File.join(__dir__, '..', 'node_modules', 'bytesize-icons', 'dist/icons')
 template = File.join(__dir__, 'README_template.md')
 readme = File.join(__dir__, '..', 'README_template.md')
-list = Dir.glob(File.join(icons, '*.svg'))
+list = ' "' + Dir.glob(File.join(icons, '*.svg'))
   .map{|f| File.basename(f, '.svg')}
   .sort
-  .map{|n| "- `<icon-#{n}></icon-#{n}>`"}
-  .join("\n")
+  .join('", "') + '".'
 puts(File.read(template) + list)


### PR DESCRIPTION
Reduce the amount of custom elements.  Make the usage easier - the difference
is only in the icon name, when included on a page.

This is a breaking change, which would have to be released in a new major version.